### PR TITLE
Advise Docker for Windows users against involving stdin/stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ will archive volume named `some_volume` to `/tmp/some_archive.tar.bz2` archive f
 
 This avoids mounting a second backup volume and allows to redirect it to a file, network, etc.
 
+**WARNING**: This method should not be used with a Docker for Windows installation; no usable backup will be generated.
+
 Syntax:
 
     docker run -v [volume-name]:/volume --rm loomchild/volume-backup backup - > [archive-name]
@@ -49,6 +51,8 @@ will clean and restore volume named `some_volume` from `/tmp/some_archive.tar.bz
 This avoids mounting a second backup volume.
 
 **Note**: Don't forget the `-i` switch for interactive operation.
+
+**WARNING**: This method should not be used with a Docker for Windows installation; no usable backup will be generated.
 
 Syntax:
 


### PR DESCRIPTION
Attempting to use backup via stdout or restore via stdin via Docker for Windows results in catastrophe; I discovered such myself in an attempt to migrate from a Windows-based host to a Linux-based host, and figured it would be worthwhile to warn others from this potential path of suffering and troubleshooting-until-2AM.