### PR TITLE
add workflow for multiarch & ghcr support

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,40 @@
+name: publish-image
+
+on:
+    workflow_dispatch:
+
+jobs:
+    docker:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v2
+
+            - name: Set up QEMU
+              uses: docker/setup-qemu-action@v1
+
+            - name: Set up Docker Buildx
+              id: buildx
+              uses: docker/setup-buildx-action@v1
+
+            - name: Login to DockerHub
+              uses: docker/login-action@v1
+              with:
+                  username: ${{ secrets.DOCKERHUB_USERNAME }}
+                  password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Login to GitHub Container Registry
+              uses: docker/login-action@v1
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.repository_owner }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build and push
+              uses: docker/build-push-action@v2
+              with:
+                  platforms: linux/amd64,linux/arm64,linux/arm/v7
+                  push: true
+                  tags: |
+                      loomchild/volume-backup:latest
+                      ghcr.io/loomchild/volume-backup:latest


### PR DESCRIPTION
## Overview

Preface: To correlate the descriptions/instructions, I will sometimes mention to look at line X of the workflow, which is `.github/workflow/publish-image.yml`.

### Multi Architecture support

Resolves #34

This PR introduces a github action workflow to automate building `volume-backup` into 3 architectures (refer line 36 of workflow), namely:
-  `linux/amd64`
-  `linux/arm64`
- `linux/arm/v7`

Setup referenced from https://github.com/docker/build-push-action/blob/master/docs/advanced/multi-platform.md

### Pushes to DockerHub and GHCR at the same time

Resolves #35

Refer line 20-31 of workflow. The tags in the end (line 39-40), particular `ghcr.io` prefix, indicates to the `docker/build-push-action@v2` step to push to each of the registry.

Setup referenced from https://github.com/docker/build-push-action/blob/master/docs/advanced/push-multi-registries.md

### How does the workflow triggers

The trigger for the github action is manual (on  `workflow_dispatch`, line 3-4 of workflow). 

The maintainers can go to Actions tab, click on **publish-image** workflow on the left, click on `Run workflow` on the bottom right there, then click on the green `Run workflow` button to trigger it. A sample screenshot depicting the steps is shown below:
![image](https://user-images.githubusercontent.com/42867097/122948886-d322ac80-d3ad-11eb-88ed-97a559562558.png)

## Proof of workflow working in my forked repo

### Terminal screenshot on a Raspberry Pi on arm64 architecture

- Pulling the image from both DockerHub and ghcr:
  ![image](https://user-images.githubusercontent.com/42867097/122950899-6b6d6100-d3af-11eb-9f45-4dc2f2aab588.png)
- Backing up an existing out-of-the-box nginx data volume and showing the content:
  ![image](https://user-images.githubusercontent.com/42867097/122952595-afad3100-d3b0-11eb-8008-f05f2595a2aa.png)

### Published images
- Link to Github Container Registry: https://github.com/azrikahar/volume-backup/pkgs/container/volume-backup
- Link to DockerHub: https://hub.docker.com/r/azrikahar/volume-backup

## Action items needed for maintainers before merging this PR

2 new repository secrets are needed to be created in order for the github action step **Login to Dockerhub** to use `secrets.DOCKERHUB_USERNAME` & `secrets.DOCKERHUB_TOKEN` (line 23-24) to login to loomchild dockerhub account successfully to push the resulting image.

Sample screenshot:
![chrome_VbgpRS51PP](https://user-images.githubusercontent.com/42867097/122610240-e08c1e00-d0b1-11eb-9d4f-3e58e344e10e.png)
Reference from github docs: https://docs.github.com/en/actions/reference/encrypted-secrets

As for the `secrets.GITHUB_TOKEN` on line 31, it is generated automatically for us so we don't have to do anything here. [Refer official docs here](https://docs.github.com/en/actions/reference/authentication-in-a-workflow#about-the-github_token-secret)

Once the 2 dockerhub secrets are added and the PR is merged, the maintainers will just need to trigger the workflow once to resolve the 2 issues referenced in the beginning.