### PR TITLE
Add support for pbzip2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,18 @@ FROM alpine
 
 RUN apk update && apk add --no-cache dumb-init bash xz tar pigz zstd
 
+RUN apk add --no-cache \
+  bzip2-dev \
+  g++ \
+  make
+
+RUN cd /tmp/ && \
+  wget -q https://launchpad.net/pbzip2/1.1/1.1.13/+download/pbzip2-1.1.13.tar.gz && \
+  tar -xzf pbzip2-1.1.13.tar.gz && \
+  cd pbzip2-1.1.13/ && \
+  make install && \
+  rm -r /tmp/pbzip2-1.1.13/
+
 COPY volume-backup.sh /
 
 ENTRYPOINT [ "/usr/bin/dumb-init", "--", "/volume-backup.sh" ]

--- a/volume-backup.sh
+++ b/volume-backup.sh
@@ -4,7 +4,7 @@ usage() {
   >&2 echo "Usage: volume-backup <backup|restore> [options]. Reads from stdin and writes to stdout. Can also read/write files (deprecated)."
   >&2 echo ""
   >&2 echo "Options:"
-  >&2 echo "  -c <algorithm> chooose compression algorithm: bz2 (default), gz, xz, pigz, zstd and 0 (none)"
+  >&2 echo "  -c <algorithm> chooose compression algorithm: bz2 (default), gz, xz, pigz, pbzip2, zstd and 0 (none)"
   >&2 echo "  -e <glob> exclude files or directories (only for backup operation)"
   >&2 echo "  -f force overwrite even if target volume is not empty during restore"
   >&2 echo "  -x <args> pass additional arguments to the Tar utility"
@@ -56,14 +56,14 @@ while getopts "h?vfc:e:x:" OPTION; do
         usage
         exit 0
         ;;
-    c)  
+    c)
         if [ -z "$OPTARG" ]; then
           usage
           exit 1
         fi
         COMPRESSION=$OPTARG
         ;;
-    e)  
+    e)
         if [ -z "$OPTARG" -o "$OPERATION" != "backup" ]; then
           usage
           exit 1
@@ -102,6 +102,10 @@ xz)
       ;;
 bz2)
       TAROPTS+=(-j)
+      EXTENSION=.tar.bz2
+      ;;
+pbzip2)
+      TAROPTS+=(-I pbzip2)
       EXTENSION=.tar.bz2
       ;;
 gz)


### PR DESCRIPTION
This change results in a larger image but decreases the time for backups by 85% when using the new option -c pbzip2. The archives are compatible. I opted for an additional option instead of replacing the default bzip2 with pbzip2 in order to give users the choice rather than changing the default behaviour.